### PR TITLE
Fixed bug in Hint Urgency

### DIFF
--- a/notify.go
+++ b/notify.go
@@ -36,9 +36,9 @@ const (
 
 // Urgency Levels
 const (
-	UrgencyLow      = 0
-	UrgencyNormal   = 1
-	UrgencyCritical = 2
+	UrgencyLow      = byte(0)
+	UrgencyNormal   = byte(1)
+	UrgencyCritical = byte(2)
 )
 
 // Hints

--- a/notify_test.go
+++ b/notify_test.go
@@ -53,3 +53,23 @@ func TestCloseNotification(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestUrgencyNotification(t *testing.T) {
+	ntfLow := NewNotification("Urgency Test", "Testing notification urgency low")
+	ntfLow.Hints = make(map[string]interface{})
+
+	ntfLow.Hints[HintUrgency] = UrgencyLow
+	_, err := ntfLow.Show()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ntfCritical := NewNotification("Urgency Test", "Testing notification urgency critical")
+	ntfCritical.Hints = make(map[string]interface{})
+
+	ntfCritical.Hints[HintUrgency] = UrgencyCritical
+	_, err = ntfCritical.Show()
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Hello,

I was trying to set the hint urgency but received a panic when trying to run the program.

For example this program panics with an error "Invalid type int":

```
$ cat notify.go 
package main

import "github.com/TheCreeper/go-notify"

func main() {
        ntf := notify.NewNotification("Test Notification", "Just a test")
        ntf.Hints = make(map[string]interface{})

        ntf.Hints[notify.HintUrgency] = notify.UrgencyCritical

        if _, err := ntf.Show(); err != nil {
                return
        }
}
```

```
$ go run notify.go 
panic: dbus: invalid type int

goroutine 1 [running]:
github.com/godbus/dbus.getSignature(0x7fb9020ba080, 0x562e80, 0x0, 0x0)
        /home/mitch/prog/go/src/github.com/godbus/dbus/sig.go:105 +0x1c2
github.com/godbus/dbus.SignatureOf(0xc820053b48, 0x1, 0x1, 0x0, 0x0)
        /home/mitch/prog/go/src/github.com/godbus/dbus/sig.go:37 +0x16e
github.com/godbus/dbus.MakeVariant(0x562e80, 0xc820076750, 0x0, 0x0, 0x0, 0x0)
        /home/mitch/prog/go/src/github.com/godbus/dbus/variant.go:20 +0x99
github.com/TheCreeper/go-notify.Notification.Show(0x0, 0x0, 0x0, 0x0, 0x0, 0x603840, 0x11, 0x5e6c90, 0xb, 0x0, ...)
        /home/mitch/prog/go/src/github.com/TheCreeper/go-notify/notify.go:223 +0x178
main.main()
        /home/mitch/prog/go/src/github.com/majormjr/gonotify/notify.go:11 +0x1c4

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1696 +0x1
exit status 2
```

Changing the urgency type to bytes fixes this error and I can set the notification urgency correctly.

I've also added some tests to check the urgency levels.
